### PR TITLE
Update AdminSiteUrls.yaml

### DIFF
--- a/AdminSiteUrls.yaml
+++ b/AdminSiteUrls.yaml
@@ -1,2 +1,2 @@
 KIT-test: https://os2borgerpc.t0.hosting.kitkube.dk
-Hilleroed-test: https://os2borgerpc-hilleroed.t0.hosting.kitkube.dk 
+Hilleroed-test: https://os2borgerpc-hilleroed.t0.hosting.kitkube.dk


### PR DESCRIPTION
Et mellemrum til sidst, gjorde at Hilleroed ikke blev vist ved installation af BorgerPC.